### PR TITLE
Enable SQLAlchemy update and delete compliance tests

### DIFF
--- a/pyathena/result_set.py
+++ b/pyathena/result_set.py
@@ -56,6 +56,7 @@ class AthenaResultSet(CursorIterator):
     # https://docs.aws.amazon.com/athena/latest/ug/data-types.html
     # Athena complex types that benefit from type hint conversion.
     _COMPLEX_TYPES: frozenset[str] = frozenset({"array", "map", "row", "struct"})
+    _DML_SUBSTATEMENT_TYPES: frozenset[str] = frozenset({"INSERT", "UPDATE", "DELETE", "MERGE"})
 
     def __init__(
         self,
@@ -318,7 +319,10 @@ class AthenaResultSet(CursorIterator):
     def description(
         self,
     ) -> list[tuple[str, str, None, None, int, int, str]] | None:
-        if self._metadata is None:
+        if self._metadata is None or (
+            self.substatement_type
+            and self.substatement_type.upper() in self._DML_SUBSTATEMENT_TYPES
+        ):
             return None
         return [
             (

--- a/tests/pyathena/test_cursor.py
+++ b/tests/pyathena/test_cursor.py
@@ -826,6 +826,7 @@ class TestCursor:
             VALUES (1, 'test1'), (2, 'test2')
             """
         )
+        assert cursor.description is None
         assert cursor.rowcount == 2
         cursor.execute(
             f"""
@@ -842,6 +843,7 @@ class TestCursor:
             WHERE id = 1
             """
         )
+        assert cursor.description is None
         assert cursor.rowcount == 1
         cursor.execute(
             f"""
@@ -873,6 +875,7 @@ class TestCursor:
               THEN UPDATE SET col1 = t2.col1
             """
         )
+        assert cursor.description is None
         assert cursor.rowcount == 1
         cursor.execute(
             f"""
@@ -895,6 +898,7 @@ class TestCursor:
             WHERE id = 2
             """
         )
+        assert cursor.description is None
         assert cursor.rowcount == 1
         cursor.execute(
             f"""

--- a/tests/sqlalchemy/test_suite.py
+++ b/tests/sqlalchemy/test_suite.py
@@ -1,11 +1,9 @@
 import pytest
-from sqlalchemy.testing import eq_
 from sqlalchemy.testing.suite import *  # noqa: F403
 from sqlalchemy.testing.suite import FetchLimitOffsetTest as _FetchLimitOffsetTest
 from sqlalchemy.testing.suite import HasTableTest as _HasTableTest
 from sqlalchemy.testing.suite import InsertBehaviorTest as _InsertBehaviorTest
 from sqlalchemy.testing.suite import IntegerTest as _IntegerTest
-from sqlalchemy.testing.suite import SimpleUpdateDeleteTest as _SimpleUpdateDeleteTest
 from sqlalchemy.testing.suite import StringTest as _StringTest
 from sqlalchemy.testing.suite import TrueDivTest as _TrueDivTest
 
@@ -27,36 +25,6 @@ del TimeMicrosecondsTest  # noqa: F821
 del TimeTest  # noqa: F821
 del TimestampMicrosecondsTest  # noqa: F821
 del UuidTest  # noqa: F821
-
-
-class SimpleUpdateDeleteTest(_SimpleUpdateDeleteTest):
-    # Athena supports UPDATE and DELETE for Iceberg tables but does not report reliable row counts.
-    __requires__ = ()
-
-    def test_update(self, connection):
-        table = self.tables.plain_pk
-        result = connection.execute(
-            table.update().where(table.c.id == 2),
-            {"data": "d2_new"},
-        )
-
-        assert not result.is_insert
-        assert not result.returns_rows
-        eq_(
-            connection.execute(table.select().order_by(table.c.id)).fetchall(),
-            [(1, "d1"), (2, "d2_new"), (3, "d3")],
-        )
-
-    def test_delete(self, connection):
-        table = self.tables.plain_pk
-        result = connection.execute(table.delete().where(table.c.id == 2))
-
-        assert not result.is_insert
-        assert not result.returns_rows
-        eq_(
-            connection.execute(table.select().order_by(table.c.id)).fetchall(),
-            [(1, "d1"), (3, "d3")],
-        )
 
 
 class HasTableTest(_HasTableTest):

--- a/tests/sqlalchemy/test_suite.py
+++ b/tests/sqlalchemy/test_suite.py
@@ -1,9 +1,11 @@
 import pytest
+from sqlalchemy.testing import eq_
 from sqlalchemy.testing.suite import *  # noqa: F403
 from sqlalchemy.testing.suite import FetchLimitOffsetTest as _FetchLimitOffsetTest
 from sqlalchemy.testing.suite import HasTableTest as _HasTableTest
 from sqlalchemy.testing.suite import InsertBehaviorTest as _InsertBehaviorTest
 from sqlalchemy.testing.suite import IntegerTest as _IntegerTest
+from sqlalchemy.testing.suite import SimpleUpdateDeleteTest as _SimpleUpdateDeleteTest
 from sqlalchemy.testing.suite import StringTest as _StringTest
 from sqlalchemy.testing.suite import TrueDivTest as _TrueDivTest
 
@@ -21,11 +23,40 @@ del JoinTest  # noqa: F821
 del LongNameBlowoutTest  # noqa: F821
 del QuotedNameArgumentTest  # noqa: F821
 del RowCountTest  # noqa: F821
-del SimpleUpdateDeleteTest  # noqa: F821
 del TimeMicrosecondsTest  # noqa: F821
 del TimeTest  # noqa: F821
 del TimestampMicrosecondsTest  # noqa: F821
 del UuidTest  # noqa: F821
+
+
+class SimpleUpdateDeleteTest(_SimpleUpdateDeleteTest):
+    # Athena supports UPDATE and DELETE for Iceberg tables but does not report reliable row counts.
+    __requires__ = ()
+
+    def test_update(self, connection):
+        table = self.tables.plain_pk
+        result = connection.execute(
+            table.update().where(table.c.id == 2),
+            {"data": "d2_new"},
+        )
+
+        assert not result.is_insert
+        assert not result.returns_rows
+        eq_(
+            connection.execute(table.select().order_by(table.c.id)).fetchall(),
+            [(1, "d1"), (2, "d2_new"), (3, "d3")],
+        )
+
+    def test_delete(self, connection):
+        table = self.tables.plain_pk
+        result = connection.execute(table.delete().where(table.c.id == 2))
+
+        assert not result.is_insert
+        assert not result.returns_rows
+        eq_(
+            connection.execute(table.select().order_by(table.c.id)).fetchall(),
+            [(1, "d1"), (3, "d3")],
+        )
 
 
 class HasTableTest(_HasTableTest):


### PR DESCRIPTION
## WHAT

Re-enable the upstream SQLAlchemy SimpleUpdateDeleteTest for Athena Iceberg tables.
Return no DB API description for INSERT, UPDATE, DELETE, and MERGE statements while preserving their UpdateCount as rowcount.
Add regression assertions for the four DML statement types.

Related to #736.

## WHY

Athena returns DML UpdateCount responses with result-set metadata even though the statements do not return rows.
PyAthena exposed that metadata as cursor.description, so SQLAlchemy classified UPDATE and DELETE results as row-returning results.
Suppressing the DML description aligns the cursor with DB API behavior and allows the standard SQLAlchemy update and delete tests to run without weakening their assertions.

## TESTING

- just lint
- SQLAlchemy SimpleUpdateDeleteTest update and delete cases: 2 passed.
- Existing PyAthena Iceberg cursor regression test: 1 passed.
- Tests used the local AWS configuration from the gitignored .env file and a single xdist worker.