### PR TITLE
Remove dead SQLAlchemy test configuration from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,10 +126,6 @@ norecursedirs = [
     "docs.*",
 ]
 
-[tool.sqla_testing]
-requirement_cls = "pyathena.sqlalchemy.requirements:Requirements"
-profile_file = "tests/sqlalchemy/profiles.txt"
-
 [tool.ruff]
 line-length = 100
 exclude = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
+# SQLAlchemy's compliance test plugin reads this section directly from setup.cfg.
+# Keep it here until sqlalchemy.testing.plugin.plugin_base supports pyproject.toml.
 [sqla_testing]
 requirement_cls = pyathena.sqlalchemy.requirements:Requirements
 profile_file = tests/sqlalchemy/profiles.txt


### PR DESCRIPTION
## WHAT

Remove the unused SQLAlchemy testing block from pyproject.toml.
Document why the equivalent configuration must remain in setup.cfg.

Closes #737.

## WHY

The SQLAlchemy compliance test plugin reads sqla_testing settings only from setup.cfg or test.cfg.
Keeping the duplicate TOML block suggests that the plugin consumes a configuration source that it never reads.

## TESTING

- just lint
- Verified that pyproject.toml no longer contains tool.sqla_testing.
- Verified that setup.cfg still exposes requirement_cls and profile_file through ConfigParser.