### PR TITLE
Add a worktree environment helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,9 @@ AWS_ATHENA_WORKGROUP=<workgroup>
 AWS_ATHENA_SPARK_WORKGROUP=<spark-workgroup>
 ```
 
+In a git worktree, run `just worktree-env` once to link the main checkout's
+gitignored `.env` into the worktree.
+
 ```bash
 export $(cat .env | xargs) && uv run pytest tests/pyathena/test_file.py -v
 ```

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ default:
 
 # Link the main checkout's gitignored .env into a worktree
 worktree-env:
-    bash scripts/worktree-env.sh
+    scripts/worktree-env.sh
 
 # Auto-fix formatting and imports
 format:

--- a/justfile
+++ b/justfile
@@ -5,6 +5,10 @@ TOX_VERSION := "4.34.1"
 default:
     @just --list
 
+# Link the main checkout's gitignored .env into a worktree
+worktree-env:
+    bash scripts/worktree-env.sh
+
 # Auto-fix formatting and imports
 format:
     # TODO: https://github.com/astral-sh/uv/issues/5903

--- a/scripts/worktree-env.sh
+++ b/scripts/worktree-env.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+worktree_root=$(git rev-parse --show-toplevel)
+common_dir=$(git rev-parse --path-format=absolute --git-common-dir)
+main_root=$(cd "$(dirname "$common_dir")" && pwd -P)
+
+cd "$worktree_root"
+
+if [ "$(pwd -P)" = "$main_root" ]; then
+    echo "This is the main checkout; nothing to link."
+    exit 0
+fi
+
+if [ -e .env ] && [ ! -L .env ]; then
+    echo ".env is already a regular file in this worktree; nothing to link."
+    exit 0
+fi
+
+if [ ! -f "$main_root/.env" ]; then
+    echo "error: $main_root/.env does not exist" >&2
+    exit 1
+fi
+
+ln -sfn "$main_root/.env" .env
+echo "Linked .env -> $main_root/.env"


### PR DESCRIPTION
## WHAT

Add a worktree-env script that links the main checkout .env file into the current git worktree.
Expose the script through the just worktree-env recipe and document the workflow in AGENTS.md.

## WHY

Gitignored environment files are not copied when git creates a worktree.
Without the link, AWS integration tests fail before collection even though the main checkout already has the required configuration.

The helper derives the main checkout from the git common directory, refuses to replace a regular .env file, and makes no change when run from the main checkout.

## TESTING

- bash syntax validation
- just worktree-env, including an idempotent second run
- Verified that the generated link remains gitignored.
- Verified that execution from the main checkout makes no change.
- just lint
- just docs lint