### PR TITLE
Update gh-action-pypi-publish to v1.14.2 for metadata 2.5 support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           uv build -v
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       - name: Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:


### PR DESCRIPTION
## WHAT
Bump `pypa/gh-action-pypi-publish` in `release.yaml` from v1.13.0 to v1.14.2 (SHA-pinned).

## WHY
The v3.36.0 release run failed at the PyPI publish step:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Recent hatchling emits core packaging metadata 2.5, which the Twine bundled in v1.13.0 does not recognize. v1.14.2 bundles Twine v7, which supports metadata 2.5 (per the upstream release notes). Nothing was uploaded to PyPI by the failed run, so re-tagging after this fix will retry the release cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)