### PR TITLE
Pin the CI test badge to the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI - Version](https://badge.fury.io/py/pyathena.svg)](https://badge.fury.io/py/pyathena)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/PyAthena.svg)](https://pypi.org/project/PyAthena/)
 [![PyPI - Downloads](https://static.pepy.tech/badge/pyathena/month)](https://pepy.tech/project/pyathena)
-[![CI - Test](https://github.com/pyathena-dev/PyAthena/actions/workflows/test.yaml/badge.svg)](https://github.com/pyathena-dev/PyAthena/actions/workflows/test.yaml)
+[![CI - Test](https://github.com/pyathena-dev/PyAthena/actions/workflows/test.yaml/badge.svg?branch=master)](https://github.com/pyathena-dev/PyAthena/actions/workflows/test.yaml?query=branch%3Amaster)
 [![CD - Docs](https://github.com/pyathena-dev/PyAthena/actions/workflows/docs.yaml/badge.svg)](https://github.com/pyathena-dev/PyAthena/actions/workflows/docs.yaml)
 [![License - MIT](https://img.shields.io/pypi/l/PyAthena.svg)](https://github.com/pyathena-dev/PyAthena/blob/master/LICENSE)
 [![linting - Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
## WHAT
Add `?branch=master` to the CI test badge in the README (and point its link at the master-filtered run list).

## WHY
Without a branch filter, the badge shows the status of the most recent `test.yaml` run on any branch. Fork PRs trigger `test.yaml` but receive no OIDC credentials for AWS, so those runs always fail — after merging #763 the README badge showed "failing" even though the latest master run (workflow_dispatch before the v3.36.0 release) succeeded. Pinning the badge to master makes it report the actual CI status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)